### PR TITLE
chore: add string literal definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 # Code Coverage
 | Statements                  | Branches                | Functions                 | Lines             |
 | --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://img.shields.io/badge/statements-89.01%25-yellow.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-79.78%25-red.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.34%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-89.82%25-yellow.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-88.58%25-yellow.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-80.18%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-91.34%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-89.41%25-yellow.svg?style=flat) |
 # Contributing Guidelines
 
 Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional documentation, we greatly value feedback and contributions from our community.

--- a/workbench-core/base/README.md
+++ b/workbench-core/base/README.md
@@ -3,7 +3,7 @@
 ## Code Coverage
 | Statements                  | Branches                | Functions                 | Lines             |
 | --------------------------- | ----------------------- | ------------------------- | ----------------- |
-| ![Statements](https://img.shields.io/badge/statements-90.49%25-brightgreen.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-80%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-90.59%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-92.04%25-brightgreen.svg?style=flat) |
+| ![Statements](https://img.shields.io/badge/statements-89.88%25-yellow.svg?style=flat) | ![Branches](https://img.shields.io/badge/branches-80.42%25-yellow.svg?style=flat) | ![Functions](https://img.shields.io/badge/functions-90.59%25-brightgreen.svg?style=flat) | ![Lines](https://img.shields.io/badge/lines-91.53%25-brightgreen.svg?style=flat) |
 # `base`
 
 > This package is intended to provide a base AWS Service class that encapsulates all the service clients and commands that the application currently requires. We use `aws-sdk` V3 to improve the load-time of the modules imported at runtime.

--- a/workbench-core/base/src/aws/helpers/dynamoDB/deleter.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/deleter.ts
@@ -130,17 +130,8 @@ class Deleter {
    * @param str - none or all_old (non case sensitive strings)
    * @returns Deleter with populated params
    */
-  public return(str: string): Deleter {
-    const upper = str.toUpperCase();
-    const allowed = ['NONE', 'ALL_OLD'];
-    if (!allowed.includes(upper)) {
-      throw new Error(
-        `"${upper}" <== is not a valid value for DeleteItem ReturnValues. Only ${allowed.join(
-          ','
-        )} are allowed.`
-      );
-    }
-    this._params.ReturnValues = upper;
+  public return(str: 'NONE' | 'ALL_OLD'): Deleter {
+    this._params.ReturnValues = str;
     return this;
   }
 
@@ -166,17 +157,8 @@ class Deleter {
    * @param str - size or none (non case sensitive)
    * @returns Deleter with populated params
    */
-  public metrics(str: string): Deleter {
-    const upper = str.toUpperCase();
-    const allowed = ['NONE', 'SIZE'];
-    if (!allowed.includes(upper)) {
-      throw new Error(
-        `"${upper}" <== is not a valid value for ReturnItemCollectionMetrics. Only ${allowed.join(
-          ','
-        )} are allowed.`
-      );
-    }
-    this._params.ReturnItemCollectionMetrics = upper;
+  public metrics(str: 'NONE' | 'SIZE'): Deleter {
+    this._params.ReturnItemCollectionMetrics = str;
     return this;
   }
 

--- a/workbench-core/base/src/aws/helpers/dynamoDB/dynamoDBService.test.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/dynamoDBService.test.ts
@@ -208,10 +208,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: return = none', async () => {
+    test('should populate params with optional param: return = NONE', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { return: 'none' };
+      const developerParams = { return: 'NONE' as const };
       const expectedParams = {
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
         TableName: 'some-table',
@@ -224,10 +224,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: return = all_old', async () => {
+    test('should populate params with optional param: return = ALL_OLD', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { return: 'all_old' };
+      const developerParams = { return: 'ALL_OLD' as const };
       const expectedParams = {
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
         TableName: 'some-table',
@@ -239,16 +239,6 @@ describe('DynamoDBService', () => {
 
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
-    });
-    test('should fail with optional param: return is invalid', async () => {
-      // BUILD
-      const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { return: 'some' };
-
-      // OPERATE n CHECK
-      expect(() => dbService.delete(key, developerParams)).toThrow(
-        `"SOME" <== is not a valid value for DeleteItem ReturnValues. Only NONE,ALL_OLD are allowed.`
-      );
     });
     test('should populate params with optional param: capacity = indexes', async () => {
       // BUILD
@@ -298,10 +288,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: metrics = none', async () => {
+    test('should populate params with optional param: metrics = NONE', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { metrics: 'none' };
+      const developerParams = { metrics: 'NONE' as const };
       const expectedParams = {
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
         TableName: 'some-table',
@@ -314,10 +304,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: metrics = size', async () => {
+    test('should populate params with optional param: metrics = SIZE', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { metrics: 'size' };
+      const developerParams = { metrics: 'SIZE' as const };
       const expectedParams = {
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
         TableName: 'some-table',
@@ -329,16 +319,6 @@ describe('DynamoDBService', () => {
 
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
-    });
-    test('should fail with optional param: metrics is invalid', async () => {
-      // BUILD
-      const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { metrics: 'lightyears' };
-
-      // OPERATE n CHECK
-      expect(() => dbService.delete(key, developerParams)).toThrow(
-        `"LIGHTYEARS" <== is not a valid value for ReturnItemCollectionMetrics. Only NONE,SIZE are allowed.`
-      );
     });
   });
   describe('getter', () => {
@@ -443,10 +423,10 @@ describe('DynamoDBService', () => {
       expect(generatedItemParams).toEqual(expectedParams);
       expect(generatedBatchParams).toBeUndefined();
     });
-    test('single get should populate params with optional param: capacity = indexes', async () => {
+    test('single get should populate params with optional param: capacity = INDEXES', async () => {
       // BUILD
       const key = { pk: { S: 'testId' }, sk: { S: 'testId' } };
-      const developerParams = { capacity: 'INDEXES' };
+      const developerParams = { capacity: 'INDEXES' as const };
       const expectedParams = {
         Key: { pk: { S: 'testId' }, sk: { S: 'testId' } },
         TableName: 'some-table',
@@ -461,10 +441,10 @@ describe('DynamoDBService', () => {
       expect(generatedItemParams).toEqual(expectedParams);
       expect(generatedBatchParams).toBeUndefined();
     });
-    test('single get should populate params with optional param: capacity = total', async () => {
+    test('single get should populate params with optional param: capacity = TOTAL', async () => {
       // BUILD
       const key = { pk: { S: 'testId' }, sk: { S: 'testId' } };
-      const developerParams = { capacity: 'total' };
+      const developerParams = { capacity: 'TOTAL' as const };
       const expectedParams = {
         Key: { pk: { S: 'testId' }, sk: { S: 'testId' } },
         TableName: 'some-table',
@@ -479,10 +459,10 @@ describe('DynamoDBService', () => {
       expect(generatedItemParams).toEqual(expectedParams);
       expect(generatedBatchParams).toBeUndefined();
     });
-    test('single get should populate params with optional param: capacity = none', async () => {
+    test('single get should populate params with optional param: capacity = NONE', async () => {
       // BUILD
       const key = { pk: { S: 'testId' }, sk: { S: 'testId' } };
-      const developerParams = { capacity: 'none' };
+      const developerParams = { capacity: 'NONE' as const };
       const expectedParams = {
         Key: { pk: { S: 'testId' }, sk: { S: 'testId' } },
         TableName: 'some-table',
@@ -497,16 +477,6 @@ describe('DynamoDBService', () => {
       expect(generatedItemParams).toEqual(expectedParams);
       expect(generatedBatchParams).toBeUndefined();
     });
-    test('single get should fail with optional param: capacity is invalid', async () => {
-      // BUILD
-      const key = { pk: { S: 'testId' }, sk: { S: 'testId' } };
-      const developerParams = { capacity: 'some' };
-
-      // OPERATE n CHECK
-      expect(() => dbService.get(key, developerParams)).toThrow(
-        `"SOME" <== is not a valid value for ReturnConsumedCapacity. Only INDEXES,TOTAL,NONE are allowed.`
-      );
-    });
     test('single get should populate params with all optional params', async () => {
       // BUILD
       const key = { pk: { S: 'testId' }, sk: { S: 'testId' } };
@@ -514,7 +484,7 @@ describe('DynamoDBService', () => {
         strong: true,
         names: { '#P': 'Percentile' },
         projection: ['status', 'createdBy'],
-        capacity: 'none'
+        capacity: 'NONE' as const
       };
       const expectedParams = {
         Key: { pk: { S: 'testId' }, sk: { S: 'testId' } },
@@ -694,13 +664,13 @@ describe('DynamoDBService', () => {
       expect(generatedBatchParams).toEqual(expectedParams);
       expect(generatedItemParams).toBeUndefined();
     });
-    test('batch get should populate params with optional param: capacity = indexes', async () => {
+    test('batch get should populate params with optional param: capacity = INDEXES', async () => {
       // BUILD
       const key = [
         { pk: { S: 'testId' }, sk: { S: 'testId' } },
         { pk: { S: 'testId2' }, sk: { S: 'testId2' } }
       ];
-      const developerParams = { capacity: 'indexes' };
+      const developerParams = { capacity: 'INDEXES' as const };
       const expectedParams = {
         RequestItems: {
           'some-table': {
@@ -721,13 +691,13 @@ describe('DynamoDBService', () => {
       expect(generatedBatchParams).toEqual(expectedParams);
       expect(generatedItemParams).toBeUndefined();
     });
-    test('batch get should populate params with optional param: capacity = total', async () => {
+    test('batch get should populate params with optional param: capacity = TOTAL', async () => {
       // BUILD
       const key = [
         { pk: { S: 'testId' }, sk: { S: 'testId' } },
         { pk: { S: 'testId2' }, sk: { S: 'testId2' } }
       ];
-      const developerParams = { capacity: 'total' };
+      const developerParams = { capacity: 'TOTAL' as const };
       const expectedParams = {
         RequestItems: {
           'some-table': {
@@ -748,13 +718,13 @@ describe('DynamoDBService', () => {
       expect(generatedBatchParams).toEqual(expectedParams);
       expect(generatedItemParams).toBeUndefined();
     });
-    test('batch get should populate params with optional param: capacity = none', async () => {
+    test('batch get should populate params with optional param: capacity = NONE', async () => {
       // BUILD
       const key = [
         { pk: { S: 'testId' }, sk: { S: 'testId' } },
         { pk: { S: 'testId2' }, sk: { S: 'testId2' } }
       ];
-      const developerParams = { capacity: 'none' };
+      const developerParams = { capacity: 'NONE' as const };
       const expectedParams = {
         RequestItems: {
           'some-table': {
@@ -774,21 +744,6 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedBatchParams).toEqual(expectedParams);
       expect(generatedItemParams).toBeUndefined();
-    });
-    test('batch get should fail with optional param: capacity is invalid', async () => {
-      // BUILD
-      const key = [
-        { pk: { S: 'testId' }, sk: { S: 'testId' } },
-        { pk: { S: 'testId2' }, sk: { S: 'testId2' } }
-      ];
-      const developerParams = { capacity: 'some' };
-
-      // OPERATE
-
-      // CHECK
-      expect(() => dbService.get(key, developerParams)).toThrow(
-        `"SOME" <== is not a valid value for ReturnConsumedCapacity. Only INDEXES,TOTAL,NONE are allowed.`
-      );
     });
   });
   describe('query', () => {
@@ -1109,9 +1064,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: select = all_attributes', async () => {
+    test('should populate params with optional param: select = ALL_ATTRIBUTES', async () => {
       // BUILD
-      const developerParams = { select: 'all_attributes' };
+      const developerParams = { select: 'ALL_ATTRIBUTES' as const };
       const expectedParams = {
         TableName: 'some-table',
         Select: 'ALL_ATTRIBUTES'
@@ -1123,9 +1078,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: select = all_projected_attributes', async () => {
+    test('should populate params with optional param: select = ALL_PROJECTED_ATTRIBUTES', async () => {
       // BUILD
-      const developerParams = { select: 'all_projected_attributes' };
+      const developerParams = { select: 'ALL_PROJECTED_ATTRIBUTES' as const };
       const expectedParams = {
         TableName: 'some-table',
         Select: 'ALL_PROJECTED_ATTRIBUTES'
@@ -1137,9 +1092,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: select = count', async () => {
+    test('should populate params with optional param: select = COUNT', async () => {
       // BUILD
-      const developerParams = { select: 'count' };
+      const developerParams = { select: 'COUNT' as const };
       const expectedParams = {
         TableName: 'some-table',
         Select: 'COUNT'
@@ -1151,9 +1106,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: select = specific_attributes', async () => {
+    test('should populate params with optional param: select = SPECIFIC_ATTRIBUTES', async () => {
       // BUILD
-      const developerParams = { select: 'specific_attributes' };
+      const developerParams = { select: 'SPECIFIC_ATTRIBUTES' as const };
       const expectedParams = {
         TableName: 'some-table',
         Select: 'SPECIFIC_ATTRIBUTES'
@@ -1165,18 +1120,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should fail with optional param: invalid select options', async () => {
-      // BUILD
-      const developerParams = { select: 'some' };
-
-      // OPERATE n CHECK
-      expect(() => dbService.query(developerParams)).toThrow(
-        `"SOME" <== is not a valid value for Select. Only ALL_ATTRIBUTES,ALL_PROJECTED_ATTRIBUTES,SPECIFIC_ATTRIBUTES,COUNT are allowed.`
-      );
-    });
     test('should fail with invalid optional params: projection but select != specific_attributes', async () => {
       // BUILD
-      const developerParams = { projection: 'status', select: 'all_attributes' };
+      const developerParams = { projection: 'status', select: 'ALL_ATTRIBUTES' as const };
 
       // OPERATE n CHECK
       expect(() => dbService.query(developerParams)).toThrow(
@@ -1225,9 +1171,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: capacity = indexes', async () => {
+    test('should populate params with optional param: capacity = INDEXES', async () => {
       // BUILD
-      const developerParams = { capacity: 'indexes' };
+      const developerParams = { capacity: 'INDEXES' as const };
       const expectedParams = {
         TableName: 'some-table',
         ReturnConsumedCapacity: 'INDEXES'
@@ -1239,9 +1185,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: capacity = total', async () => {
+    test('should populate params with optional param: capacity = TOTAL', async () => {
       // BUILD
-      const developerParams = { capacity: 'total' };
+      const developerParams = { capacity: 'TOTAL' as const };
       const expectedParams = {
         TableName: 'some-table',
         ReturnConsumedCapacity: 'TOTAL'
@@ -1253,9 +1199,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: capacity = none', async () => {
+    test('should populate params with optional param: capacity = NONE', async () => {
       // BUILD
-      const developerParams = { capacity: 'none' };
+      const developerParams = { capacity: 'NONE' as const };
       const expectedParams = {
         TableName: 'some-table',
         ReturnConsumedCapacity: 'NONE'
@@ -1266,15 +1212,6 @@ describe('DynamoDBService', () => {
 
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
-    });
-    test('should fail with optional param: capacity is invalid', async () => {
-      // BUILD
-      const developerParams = { capacity: 'some' };
-
-      // OPERATE n CHECK
-      expect(() => dbService.query(developerParams)).toThrow(
-        `"SOME" <== is not a valid value for ReturnConsumedCapacity. Only INDEXES,TOTAL,NONE are allowed.`
-      );
     });
   });
   describe('scanner', () => {
@@ -1416,9 +1353,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: select = all_attributes', async () => {
+    test('should populate params with optional param: select = ALL_ATTRIBUTES', async () => {
       // BUILD
-      const developerParams = { select: 'all_attributes' };
+      const developerParams = { select: 'ALL_ATTRIBUTES' as const };
       const expectedParams = {
         TableName: 'some-table',
         Select: 'ALL_ATTRIBUTES'
@@ -1430,9 +1367,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: select = all_projected_attributes', async () => {
+    test('should populate params with optional param: select = ALL_PROJECTED_ATTRIBUTES', async () => {
       // BUILD
-      const developerParams = { select: 'all_projected_attributes' };
+      const developerParams = { select: 'ALL_PROJECTED_ATTRIBUTES' as const };
       const expectedParams = {
         TableName: 'some-table',
         Select: 'ALL_PROJECTED_ATTRIBUTES'
@@ -1444,9 +1381,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: select = count', async () => {
+    test('should populate params with optional param: select = COUNT', async () => {
       // BUILD
-      const developerParams = { select: 'count' };
+      const developerParams = { select: 'COUNT' as const };
       const expectedParams = {
         TableName: 'some-table',
         Select: 'COUNT'
@@ -1458,9 +1395,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: select = specific_attributes', async () => {
+    test('should populate params with optional param: select = SPECIFIC_ATTRIBUTES', async () => {
       // BUILD
-      const developerParams = { select: 'specific_attributes' };
+      const developerParams = { select: 'SPECIFIC_ATTRIBUTES' as const };
       const expectedParams = {
         TableName: 'some-table',
         Select: 'SPECIFIC_ATTRIBUTES'
@@ -1471,15 +1408,6 @@ describe('DynamoDBService', () => {
 
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
-    });
-    test('should fail with optional param: invalid select options', async () => {
-      // BUILD
-      const developerParams = { select: 'some' };
-
-      // OPERATE n CHECK
-      expect(() => dbService.scan(developerParams)).toThrow(
-        `"SOME" <== is not a valid value for Select. Only ALL_ATTRIBUTES,ALL_PROJECTED_ATTRIBUTES,SPECIFIC_ATTRIBUTES,COUNT are allowed.`
-      );
     });
     test('should populate params with optional param: limit', async () => {
       // BUILD
@@ -1510,9 +1438,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: capacity = indexes', async () => {
+    test('should populate params with optional param: capacity = INDEXES', async () => {
       // BUILD
-      const developerParams = { capacity: 'indexes' };
+      const developerParams = { capacity: 'INDEXES' as const };
       const expectedParams = {
         TableName: 'some-table',
         ReturnConsumedCapacity: 'INDEXES'
@@ -1524,9 +1452,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: capacity = total', async () => {
+    test('should populate params with optional param: capacity = TOTAL', async () => {
       // BUILD
-      const developerParams = { capacity: 'total' };
+      const developerParams = { capacity: 'TOTAL' as const };
       const expectedParams = {
         TableName: 'some-table',
         ReturnConsumedCapacity: 'TOTAL'
@@ -1538,9 +1466,9 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: capacity = none', async () => {
+    test('should populate params with optional param: capacity = NONE', async () => {
       // BUILD
-      const developerParams = { capacity: 'none' };
+      const developerParams = { capacity: 'NONE' as const };
       const expectedParams = {
         TableName: 'some-table',
         ReturnConsumedCapacity: 'NONE'
@@ -1551,15 +1479,6 @@ describe('DynamoDBService', () => {
 
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
-    });
-    test('should fail with optional param: capacity is invalid', async () => {
-      // BUILD
-      const developerParams = { capacity: 'some' };
-
-      // OPERATE n CHECK
-      expect(() => dbService.scan(developerParams)).toThrow(
-        `"SOME" <== is not a valid value for ReturnConsumedCapacity. Only INDEXES,TOTAL,NONE are allowed.`
-      );
     });
   });
   describe('updater', () => {
@@ -1712,10 +1631,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: return = none', async () => {
+    test('should populate params with optional param: return = NONE', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { return: 'none' };
+      const developerParams = { return: 'NONE' as const };
       const expectedParams = {
         TableName: 'some-table',
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
@@ -1728,10 +1647,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: return = all_old', async () => {
+    test('should populate params with optional param: return = ALL_OLD', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { return: 'all_old' };
+      const developerParams = { return: 'ALL_OLD' as const };
       const expectedParams = {
         TableName: 'some-table',
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
@@ -1744,10 +1663,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: return = updated_old', async () => {
+    test('should populate params with optional param: return = UPDATED_OLD', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { return: 'updated_old' };
+      const developerParams = { return: 'UPDATED_OLD' as const };
       const expectedParams = {
         TableName: 'some-table',
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
@@ -1760,10 +1679,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: return = all_new', async () => {
+    test('should populate params with optional param: return = ALL_NEW', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { return: 'all_new' };
+      const developerParams = { return: 'ALL_NEW' as const };
       const expectedParams = {
         TableName: 'some-table',
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
@@ -1776,10 +1695,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: return = updated_new', async () => {
+    test('should populate params with optional param: return = UPDATED_NEW', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { return: 'updated_new' };
+      const developerParams = { return: 'UPDATED_NEW' as const };
       const expectedParams = {
         TableName: 'some-table',
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
@@ -1792,20 +1711,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should fail with optional param: return is invalid', async () => {
+    test('should populate params with optional param: metrics = NONE', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { return: 'some' };
-
-      // OPERATE n CHECK
-      expect(() => dbService.update(key, developerParams)).toThrow(
-        `"SOME" <== is not a valid value for ReturnValues. Only NONE,ALL_OLD,UPDATED_OLD,ALL_NEW,UPDATED_NEW are allowed.`
-      );
-    });
-    test('should populate params with optional param: metrics = none', async () => {
-      // BUILD
-      const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { metrics: 'none' };
+      const developerParams = { metrics: 'NONE' as const };
       const expectedParams = {
         TableName: 'some-table',
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
@@ -1819,10 +1728,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: metrics = size', async () => {
+    test('should populate params with optional param: metrics = SIZE', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { metrics: 'size' };
+      const developerParams = { metrics: 'SIZE' as const };
       const expectedParams = {
         TableName: 'some-table',
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
@@ -1836,20 +1745,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should fail with optional param: metrics is invalid', async () => {
+    test('should populate params with optional param: capacity = INDEXES', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { metrics: 'lightyears' };
-
-      // OPERATE n CHECK
-      expect(() => dbService.update(key, developerParams)).toThrow(
-        `"LIGHTYEARS" <== is not a valid value for ReturnItemCollectionMetrics. Only NONE,SIZE are allowed.`
-      );
-    });
-    test('should populate params with optional param: capacity = indexes', async () => {
-      // BUILD
-      const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { capacity: 'indexes' };
+      const developerParams = { capacity: 'INDEXES' as const };
       const expectedParams = {
         TableName: 'some-table',
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
@@ -1863,10 +1762,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: capacity = total', async () => {
+    test('should populate params with optional param: capacity = TOTAL', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { capacity: 'total' };
+      const developerParams = { capacity: 'TOTAL' as const };
       const expectedParams = {
         TableName: 'some-table',
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
@@ -1880,10 +1779,10 @@ describe('DynamoDBService', () => {
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
     });
-    test('should populate params with optional param: capacity = none', async () => {
+    test('should populate params with optional param: capacity = NONE', async () => {
       // BUILD
       const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { capacity: 'none' };
+      const developerParams = { capacity: 'NONE' as const };
       const expectedParams = {
         TableName: 'some-table',
         Key: { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } },
@@ -1896,16 +1795,6 @@ describe('DynamoDBService', () => {
 
       // CHECK
       expect(generatedParams).toEqual(expectedParams);
-    });
-    test('should fail zwith optional param: capacity is invalid', async () => {
-      // BUILD
-      const key = { pk: { S: 'samplePK' }, sk: { S: 'sampleSK' } };
-      const developerParams = { capacity: 'some' };
-
-      // OPERATE n CHECK
-      expect(() => dbService.update(key, developerParams)).toThrow(
-        `"SOME" <== is not a valid value for ReturnConsumedCapacity. Only INDEXES,TOTAL,NONE are allowed.`
-      );
     });
   });
 });

--- a/workbench-core/base/src/aws/helpers/dynamoDB/dynamoDBService.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/dynamoDBService.ts
@@ -49,11 +49,11 @@ export default class DynamoDBService {
     names?: { [key: string]: string };
     values?: { [key: string]: AttributeValue };
     projection?: string | string[];
-    select?: string;
+    select?: 'ALL_ATTRIBUTES' | 'ALL_PROJECTED_ATTRIBUTES' | 'SPECIFIC_ATTRIBUTES' | 'COUNT';
     limit?: number;
     segment?: number;
     totalSegment?: number;
-    capacity?: string;
+    capacity?: 'INDEXES' | 'TOTAL' | 'NONE';
   }): Scanner {
     let scanner = new Scanner({ region: this._awsRegion }, this._tableName);
     if (params) {
@@ -119,7 +119,7 @@ export default class DynamoDBService {
       strong?: boolean;
       names?: { [key: string]: string };
       projection?: string | string[];
-      capacity?: string;
+      capacity?: 'INDEXES' | 'TOTAL' | 'NONE';
     }
   ): Getter {
     let getter = new Getter({ region: this._awsRegion }, this._tableName, key);
@@ -175,10 +175,10 @@ export default class DynamoDBService {
     names?: { [key: string]: string };
     values?: { [key: string]: AttributeValue };
     projection?: string | string[];
-    select?: string;
+    select?: 'ALL_ATTRIBUTES' | 'ALL_PROJECTED_ATTRIBUTES' | 'SPECIFIC_ATTRIBUTES' | 'COUNT';
     limit?: number;
     forward?: boolean;
-    capacity?: string;
+    capacity?: 'INDEXES' | 'TOTAL' | 'NONE';
   }): Query {
     let query = new Query({ region: this._awsRegion }, this._tableName);
     if (params) {
@@ -297,9 +297,9 @@ export default class DynamoDBService {
       delete?: string;
       names?: { [key: string]: string };
       values?: { [key: string]: AttributeValue };
-      return?: string;
-      metrics?: string;
-      capacity?: string;
+      return?: 'NONE' | 'ALL_OLD' | 'UPDATED_OLD' | 'ALL_NEW' | 'UPDATED_NEW';
+      metrics?: 'NONE' | 'SIZE';
+      capacity?: 'INDEXES' | 'TOTAL' | 'NONE';
     }
   ): Updater {
     let updater = new Updater({ region: this._awsRegion }, this._tableName, key);
@@ -369,9 +369,9 @@ export default class DynamoDBService {
       condition?: string;
       names?: { [key: string]: string };
       values?: { [key: string]: AttributeValue };
-      return?: string;
+      return?: 'NONE' | 'ALL_OLD';
       capacity?: 'INDEXES' | 'TOTAL' | 'NONE';
-      metrics?: string;
+      metrics?: 'NONE' | 'SIZE';
     }
   ): Deleter {
     let deleter = new Deleter({ region: this._awsRegion }, this._tableName, key);

--- a/workbench-core/base/src/aws/helpers/dynamoDB/getter.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/getter.ts
@@ -255,20 +255,11 @@ class Getter {
    * @param str - indexes, total, or none (non case sensitive strings)
    * @returns Getter with populated params
    */
-  public capacity(str: string = ''): Getter {
-    const upper = str.toUpperCase();
-    const allowed = ['INDEXES', 'TOTAL', 'NONE'];
-    if (!allowed.includes(upper)) {
-      throw new Error(
-        `"${upper}" <== is not a valid value for ReturnConsumedCapacity. Only ${allowed.join(
-          ','
-        )} are allowed.`
-      );
-    }
+  public capacity(str: 'INDEXES' | 'TOTAL' | 'NONE'): Getter {
     if (this._paramsItem) {
-      this._paramsItem.ReturnConsumedCapacity = upper;
+      this._paramsItem.ReturnConsumedCapacity = str;
     } else if (this._paramsBatch) {
-      this._paramsBatch.ReturnConsumedCapacity = upper;
+      this._paramsBatch.ReturnConsumedCapacity = str;
     }
     return this;
   }

--- a/workbench-core/base/src/aws/helpers/dynamoDB/query.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/query.ts
@@ -388,18 +388,11 @@ class Query {
    * @param str - ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, or COUNT (not case sensitive)
    * @returns Query with populated params
    */
-  public select(str: string): Query {
-    const upper = str.toUpperCase();
-    const allowed = ['ALL_ATTRIBUTES', 'ALL_PROJECTED_ATTRIBUTES', 'SPECIFIC_ATTRIBUTES', 'COUNT'];
-    if (!allowed.includes(upper)) {
-      throw new Error(
-        `"${upper}" <== is not a valid value for Select. Only ${allowed.join(',')} are allowed.`
-      );
-    }
-    if (this._params.ProjectionExpression && upper !== 'SPECIFIC_ATTRIBUTES') {
+  public select(str: 'ALL_ATTRIBUTES' | 'ALL_PROJECTED_ATTRIBUTES' | 'SPECIFIC_ATTRIBUTES' | 'COUNT'): Query {
+    if (this._params.ProjectionExpression && str !== 'SPECIFIC_ATTRIBUTES') {
       throw new Error(`You cannot select values except SPECIFIC_ATTRIBUTES when using projectionExpression`);
     }
-    this._params.Select = upper;
+    this._params.Select = str;
     return this;
   }
 
@@ -438,17 +431,8 @@ class Query {
    * @param str - indexes, total, or none (non case sensitive strings)
    * @returns Query with populated params
    */
-  public capacity(str: string = ''): Query {
-    const upper = str.toUpperCase();
-    const allowed = ['INDEXES', 'TOTAL', 'NONE'];
-    if (!allowed.includes(upper)) {
-      throw new Error(
-        `"${upper}" <== is not a valid value for ReturnConsumedCapacity. Only ${allowed.join(
-          ','
-        )} are allowed.`
-      );
-    }
-    this._params.ReturnConsumedCapacity = upper;
+  public capacity(str: 'INDEXES' | 'TOTAL' | 'NONE'): Query {
+    this._params.ReturnConsumedCapacity = str;
     return this;
   }
 

--- a/workbench-core/base/src/aws/helpers/dynamoDB/scanner.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/scanner.ts
@@ -197,15 +197,10 @@ class Scanner {
    * @param str - ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, or COUNT (not case sensitive)
    * @returns Scanner with populated params
    */
-  public select(str: string): Scanner {
-    const upper = str.toUpperCase();
-    const allowed = ['ALL_ATTRIBUTES', 'ALL_PROJECTED_ATTRIBUTES', 'SPECIFIC_ATTRIBUTES', 'COUNT'];
-    if (!allowed.includes(upper)) {
-      throw new Error(
-        `"${upper}" <== is not a valid value for Select. Only ${allowed.join(',')} are allowed.`
-      );
-    }
-    this._params.Select = upper;
+  public select(
+    str: 'ALL_ATTRIBUTES' | 'ALL_PROJECTED_ATTRIBUTES' | 'SPECIFIC_ATTRIBUTES' | 'COUNT'
+  ): Scanner {
+    this._params.Select = str;
     return this;
   }
 
@@ -267,17 +262,8 @@ class Scanner {
    * @param str - indexes, total, or none (non case sensitive strings)
    * @returns Scanner with populated params
    */
-  public capacity(str: string = ''): Scanner {
-    const upper = str.toUpperCase();
-    const allowed = ['INDEXES', 'TOTAL', 'NONE'];
-    if (!allowed.includes(upper)) {
-      throw new Error(
-        `"${upper}" <== is not a valid value for ReturnConsumedCapacity. Only ${allowed.join(
-          ','
-        )} are allowed.`
-      );
-    }
-    this._params.ReturnConsumedCapacity = upper;
+  public capacity(str: 'INDEXES' | 'TOTAL' | 'NONE'): Scanner {
+    this._params.ReturnConsumedCapacity = str;
     return this;
   }
 

--- a/workbench-core/base/src/aws/helpers/dynamoDB/updater.test.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/updater.test.ts
@@ -238,7 +238,6 @@ describe('updater', () => {
       .key({ pk: { S: 'pk' } })
       .remove(['attr1ToRemove', 'attr2ToRemove'])
       .getParams();
-    console.log(generatedParams);
 
     // CHECK
     expect(generatedParams.UpdateExpression).toEqual(expectedParams.UpdateExpression);

--- a/workbench-core/base/src/aws/helpers/dynamoDB/updater.ts
+++ b/workbench-core/base/src/aws/helpers/dynamoDB/updater.ts
@@ -444,15 +444,8 @@ class Updater {
    * @param str - NONE, ALL_OLD, UPDATED_OLD, ALL_NEW, or UPDATED_NEW (not case sensitive)
    * @returns Updater with populated params
    */
-  public return(str: string): Updater {
-    const upper = str.toUpperCase();
-    const allowed = ['NONE', 'ALL_OLD', 'UPDATED_OLD', 'ALL_NEW', 'UPDATED_NEW'];
-    if (!allowed.includes(upper)) {
-      throw new Error(
-        `"${upper}" <== is not a valid value for ReturnValues. Only ${allowed.join(',')} are allowed.`
-      );
-    }
-    this._params.ReturnValues = upper;
+  public return(str: 'NONE' | 'ALL_OLD' | 'UPDATED_OLD' | 'ALL_NEW' | 'UPDATED_NEW'): Updater {
+    this._params.ReturnValues = str;
     return this;
   }
 
@@ -465,17 +458,8 @@ class Updater {
    * @returns Updater with populated params
    */
   // same as ReturnItemCollectionMetrics
-  public metrics(str: string): Updater {
-    const upper = str.toUpperCase();
-    const allowed = ['NONE', 'SIZE'];
-    if (!allowed.includes(upper)) {
-      throw new Error(
-        `"${upper}" <== is not a valid value for ReturnItemCollectionMetrics. Only ${allowed.join(
-          ','
-        )} are allowed.`
-      );
-    }
-    this._params.ReturnItemCollectionMetrics = upper;
+  public metrics(str: 'NONE' | 'SIZE'): Updater {
+    this._params.ReturnItemCollectionMetrics = str;
     return this;
   }
 
@@ -489,17 +473,8 @@ class Updater {
    * @returns Updater with populated params
    */
   // same as ReturnConsumedCapacity
-  public capacity(str: string = ''): Updater {
-    const upper = str.toUpperCase();
-    const allowed = ['INDEXES', 'TOTAL', 'NONE'];
-    if (!allowed.includes(upper)) {
-      throw new Error(
-        `"${upper}" <== is not a valid value for ReturnConsumedCapacity. Only ${allowed.join(
-          ','
-        )} are allowed.`
-      );
-    }
-    this._params.ReturnConsumedCapacity = upper;
+  public capacity(str: 'INDEXES' | 'TOTAL' | 'NONE'): Updater {
+    this._params.ReturnConsumedCapacity = str;
     return this;
   }
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Adding `string literal types` makes our code simpler because we don't have to add additional checks to validate a method's input parameter. It also makes the developer experience better because they'll be able to catch method input errors in their IDE instead of at run time.

[More info on literal string types here](https://mariusschulz.com/blog/string-literal-types-in-typescript)

AWS SDK v3 definition of `ReturnConsumedCapacity` [here](https://github.com/aws/aws-sdk-js-v3/blob/94be85ad97/clients/client-dynamodb/src/models/models_0.ts#L1065)
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.