### PR TITLE
fix: ignore pnpm-lock.yaml file

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -24,3 +24,4 @@ jobs:
             'This PR exceeds the recommended size of 1000 lines.
             Please make sure you are NOT addressing multiple issues with one PR.
             Note this PR might be rejected due to its size.’
+          files_to_ignore: 'pnpm-lock.yaml'


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
For PRs we do not care how large a change is in the lock file, so lets ignore it :)

re: https://github.com/CodelyTV/pr-size-labeler

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.