### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-.guthub                                               @rsmayda @DaveMadsen @insignias @htztomic @bhudnell
+.github                                               @rsmayda @DaveMadsen @insignias @htztomic @bhudnell
 common                                                @rsmayda @DaveMadsen @insignias @htztomic @bhudnell
 common/config/rush/browser-approved-packages.json
 common/config/rush/nonbrowser-approved-packages.json


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Code owners are automatically requested for review when someone opens a pull request that modifies code that they own. Code owners are not automatically requested to review draft pull requests. For more information about draft pull requests, see "[About pull requests](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)." When you mark a draft pull request as ready for review, code owners are automatically notified. If you convert a pull request to a draft, people who are already subscribed to notifications are not automatically unsubscribed

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.