### PR TITLE
chore: cleaner way to specify owners in CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,32 +1,17 @@
-*                                                     @rsmayda @DaveMadsen @insignias @htztomic @bhudnell
+*                                                     @awslabs/aws-ma-foundation
 common/config/rush/browser-approved-packages.json
 common/config/rush/nonbrowser-approved-packages.json
 common/config/rush/pnpm-lock.yaml
 common/changes/
 solutions/example-ui-app                              @mabreuortega
-solutions/swb-ui                                      @kpark277
-common/changes/@amzn/swb-ui                           @kpark277
-solutions/swb-reference                               @nguyen102 @SanketD92 @maghirardelli
-common/changes/@amzn/swb-reference                    @nguyen102 @SanketD92 @maghirardelli
-solutions/swb-app                                     @nguyen102 @SanketD92 @maghirardelli
-common/changes/@amzn/swb-app                          @nguyen102 @SanketD92 @maghirardelli
-solutions/managed-blockchain-for-patient-consent      @Bingjiling
-workbench-core/audit                                  @htztomic
-common/changes/@amzn/workbench-core-audit             @htztomic
-workbench-core/authentication                         @bhudnell
-common/changes/@amzn/workbench-core-authentication    @bhudnell
-workbench-core/authorization                          @htztomic
-common/changes/@amzn/workbench-core-authorization     @htztomic
-workbench-core/base                                   @nguyen102 @SanketD92 @maghirardelli
-common/changes/@amzn/workbench-core-base              @nguyen102 @SanketD92 @maghirardelli
-workbench-core/datasets                               @DaveMadsen
-common/changes/@amzn/workbench-core-datasets          @DaveMadsen
-workbench-core/environments                           @nguyen102 @SanketD92 @maghirardelli
-common/changes/@amzn/environments                     @nguyen102 @SanketD92 @maghirardelli
-workbench-core/eslint-custom                          @insignias
-workbench-core/infrastructure                         @bhudnell
-common/changes/@amzn/workbench-core-infrastructure    @bhudnell
-workbench-core/example                                @insignias
-workbench-core/logging                                @bhudnell
-common/changes/@amzn/workbench-core-logging           @bhudnell
-workbench-core/repo-scripts/repo-toolbox              @insignias
+solutions/swb-ui                                      @awslabs/aws-ma-swb
+common/changes/@amzn/swb-ui                           @awslabs/aws-ma-swb
+solutions/swb-reference                               @awslabs/aws-ma-swb
+common/changes/@amzn/swb-reference                    @awslabs/aws-ma-swb
+solutions/swb-app                                     @awslabs/aws-ma-swb
+common/changes/@amzn/swb-app                          @awslabs/aws-ma-swb
+solutions/managed-blockchain-for-patient-consent      @awslabs/aws-ma-magellan
+workbench-core/base                                   @awslabs/aws-ma-swb
+common/changes/@amzn/workbench-core-base              @awslabs/aws-ma-swb
+workbench-core/environments                           @awslabs/aws-ma-swb
+common/changes/@amzn/environments                     @awslabs/aws-ma-swb


### PR DESCRIPTION
Issue #, if available:

Description of changes:
All files are owned by MAF developer team unless other teams/owners are specified

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.