### PR TITLE
fix: environment route should throw 400 when envType is not supported

### DIFF
--- a/solutions/swb-app/src/environmentRoutes.ts
+++ b/solutions/swb-app/src/environmentRoutes.ts
@@ -46,7 +46,7 @@ export function setUpEnvRoutes(
         }
         res.status(201).send(env);
       } else {
-        res.send(
+        throw Boom.badRequest(
           `No service provided for environment ${envType}. Supported environments types are: ${supportedEnvs}`
         );
       }
@@ -65,7 +65,7 @@ export function setUpEnvRoutes(
         const response = await environments[envType].lifecycle.terminate(req.params.id);
         res.send(response);
       } else {
-        res.send(
+        throw Boom.badRequest(
           `No service provided for environment ${envType}. Supported environments types are: ${supportedEnvs}`
         );
       }
@@ -84,7 +84,7 @@ export function setUpEnvRoutes(
         const response = await environments[envType].lifecycle.start(req.params.id);
         res.send(response);
       } else {
-        res.send(
+        throw Boom.badRequest(
           `No service provided for environment ${envType}. Supported environments types are: ${supportedEnvs}`
         );
       }
@@ -103,7 +103,7 @@ export function setUpEnvRoutes(
         const response = await environments[envType].lifecycle.stop(req.params.id);
         res.send(response);
       } else {
-        res.send(
+        throw Boom.badRequest(
           `No service provided for environment ${envType}. Supported environments types are: ${supportedEnvs}`
         );
       }
@@ -141,7 +141,7 @@ export function setUpEnvRoutes(
         };
         res.send(response);
       } else {
-        res.send(
+        throw Boom.badRequest(
           `No service provided for environment ${envType}. Supported environments types are: ${supportedEnvs}`
         );
       }


### PR DESCRIPTION
Issue #, if available:

Description of changes:
fix: environment route should throw 400 when envType is not supported


**Testing**
API return `400` when `envType` is not supported

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.