### PR TITLE
fix(sagemaker cfn): restrict kms permissions

### DIFF
--- a/solutions/swb-reference/src/environment/sagemakerNotebook/sagemakerNotebook.cfn.yaml
+++ b/solutions/swb-reference/src/environment/sagemakerNotebook/sagemakerNotebook.cfn.yaml
@@ -113,7 +113,7 @@ Resources:
               - 'kms:GenerateDataKeyWithoutPlaintext'
               - 'kms:Get*'
               - 'kms:List*'
-            Resource: '*'
+            Resource: !Ref EncryptionKeyArn
           - Effect: Allow
             Action:
               - 'sts:AssumeRole'


### PR DESCRIPTION
restrict the kms permissions to be on the passed kms key only

Issue #, if available: GALI-1613

Description of changes: get rid of wildcard in kms permissions resource


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.