### PR TITLE
fix(servicecatalogsetup): add sort function

### DIFF
--- a/workbench-core/environments/src/postDeployment/serviceCatalogSetup.ts
+++ b/workbench-core/environments/src/postDeployment/serviceCatalogSetup.ts
@@ -223,7 +223,9 @@ export default class ServiceCatalogSetup {
         .map((name) => {
           return Number(name.replace('v', ''));
         })
-        .sort()
+        .sort((a, b) => {
+          return a - b;
+        })
         .pop();
 
       if (largestVersionNumber === undefined) {


### PR DESCRIPTION
Issue #, if available: GALI-1613

Description of changes: Add sort function so it properly pops largest number not ASCII-ordered number


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.