### PR TITLE
fix(swb-reference): fix test environment domain to not use reserved word

### DIFF
--- a/solutions/swb-reference/src/config/testEnv.yaml
+++ b/solutions/swb-reference/src/config/testEnv.yaml
@@ -4,5 +4,5 @@ awsRegion: us-east-1
 awsRegionShortName: va
 rootUserEmail: aws-chamonix-dev+testEnvRoot@amazon.com
 allowedOrigins: ['http://localhost:3000', 'http://localhost:3002']
-cognitoDomain: 'aws-chamonix-dev-test-domain'
+cognitoDomain: 'chamonix-dev-test-domain'
 websiteUrl: 'http://localhost:3000'


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Cognito domain is not allowed to use words "aws", "amazon", or "cognito".

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.