### PR TITLE
fix: envType/Conf use correct user;disable terminate for running env;…

### DIFF
--- a/solutions/swb-app/src/environmentTypeConfigRoutes.ts
+++ b/solutions/swb-app/src/environmentTypeConfigRoutes.ts
@@ -22,13 +22,9 @@ export function setUpEnvTypeConfigRoutes(
         throw Boom.badRequest('envTypeId request parameter must be a valid uuid.');
       }
       processValidatorResult(validate(req.body, CreateEnvironmentTypeConfigSchema));
-      // TODO: Get user information from req context once Auth has been integrated
-      const user = {
-        role: 'admin',
-        ownerId: 'owner-123'
-      };
+      const user = res.locals.user;
       const envTypeConfig = await environmentTypeConfigService.createNewEnvironmentTypeConfig(
-        user.ownerId,
+        user.id,
         req.params.envTypeId,
         req.body
       );
@@ -91,14 +87,9 @@ export function setUpEnvTypeConfigRoutes(
       }
 
       processValidatorResult(validate(req.body, UpdateEnvironmentTypeConfigSchema));
-
-      // TODO: Get user information from req context once Auth has been integrated
-      const user = {
-        role: 'admin',
-        ownerId: 'owner-123'
-      };
+      const user = res.locals.user;
       const envTypeConfig = await environmentTypeConfigService.updateEnvironmentTypeConfig(
-        user.ownerId,
+        user.id,
         req.params.envTypeId,
         req.params.envTypeConfigId,
         req.body

--- a/solutions/swb-app/src/environmentTypeRoutes.ts
+++ b/solutions/swb-app/src/environmentTypeRoutes.ts
@@ -25,12 +25,8 @@ export function setUpEnvTypeRoutes(router: Router, environmentTypeService: Envir
           `Status provided is: ${status}. Status needs to be one of these values: ${ENVIRONMENT_TYPE_STATUS}`
         );
       }
-      // TODO: Get user information from req context once Auth has been integrated
-      const user = {
-        role: 'admin',
-        ownerId: 'owner-123'
-      };
-      const envType = await environmentTypeService.createNewEnvironmentType(user.ownerId, {
+      const user = res.locals.user;
+      const envType = await environmentTypeService.createNewEnvironmentType(user.id, {
         ...req.body
       });
       res.status(201).send(envType);
@@ -76,22 +72,14 @@ export function setUpEnvTypeRoutes(router: Router, environmentTypeService: Envir
         throw Boom.badRequest('id request parameter must be a valid uuid.');
       }
       processValidatorResult(validate(req.body, UpdateEnvironmentTypeSchema));
-      // TODO: Get user information from req context once Auth has been integrated
-      const user = {
-        role: 'admin',
-        ownerId: 'owner-123'
-      };
+      const user = res.locals.user;
       const { status } = req.body;
       if (!isEnvironmentTypeStatus(status)) {
         throw Boom.badRequest(
           `Status provided is: ${status}. Status needs to be one of these values: ${ENVIRONMENT_TYPE_STATUS}`
         );
       }
-      const envType = await environmentTypeService.updateEnvironmentType(
-        user.ownerId,
-        req.params.id,
-        req.body
-      );
+      const envType = await environmentTypeService.updateEnvironmentType(user.id, req.params.id, req.body);
       res.status(200).send(envType);
     })
   );

--- a/solutions/swb-reference/src/SWBStack.ts
+++ b/solutions/swb-reference/src/SWBStack.ts
@@ -169,7 +169,7 @@ export class SWBStack extends Stack {
     return key;
   }
 
-private _createLaunchConstraintIAMRole(
+  private _createLaunchConstraintIAMRole(
     launchConstraintRoleNameOutput: string,
     artifactS3Bucket: Bucket
   ): Role {
@@ -506,59 +506,59 @@ private _createLaunchConstraintIAMRole(
     const amiIdsList: string[] = JSON.parse(amiIdsToShare);
 
     const lambdaPolicy = new Policy(this, 'accountHandlerPolicy', {
-        statements: [
-          new PolicyStatement({
-            sid: 'CreatePortfolioShare',
-            actions: ['servicecatalog:CreatePortfolioShare'],
-            resources: [`arn:aws:catalog:${this.region}:${this.account}:portfolio/*`]
-          }),
-          // Allows accountHandler to get portfolioId based on portfolioName
-          // '*/*' is the minimum permission required because ListPortfolios API does not allow filtering
-          new PolicyStatement({
-            sid: 'ListPortfolios',
-            actions: ['servicecatalog:ListPortfolios'],
-            resources: [`arn:aws:servicecatalog:${this.region}:${this.account}:*/*`]
-          }),
-          new PolicyStatement({
-            actions: ['kms:GetKeyPolicy', 'kms:PutKeyPolicy'],
-            resources: [`arn:aws:kms:${this.region}:${this.account}:key/*`],
-            sid: 'KMSAccess'
-          }),
-          new PolicyStatement({
-            sid: 'AssumeRole',
-            actions: ['sts:AssumeRole'],
-            // Confirm the suffix `hosting-account-role` matches with the suffix in `onboard-account.cfn.yaml`
-            resources: ['arn:aws:iam::*:role/*hosting-account-role']
-          }),
-          new PolicyStatement({
-            sid: 'GetLaunchConstraint',
-            actions: [
-              'iam:GetRole',
-              'iam:GetRolePolicy',
-              'iam:ListRolePolicies',
-              'iam:ListAttachedRolePolicies'
-            ],
-            resources: [launchConstraintRole.roleArn]
-          }),
-          new PolicyStatement({
-            sid: 'ShareSSM',
-            actions: ['ssm:ModifyDocumentPermission'],
-            resources: [
-              this.formatArn({ service: 'ssm', resource: 'document', resourceName: `${this.stackName}-*` })
-            ]
-          }),
-          new PolicyStatement({
-            sid: 'Cloudformation',
-            actions: ['cloudformation:DescribeStacks'],
-            resources: [this.stackId]
-          }),
-          new PolicyStatement({
-            sid: 'S3Bucket',
-            actions: ['s3:GetObject'],
-            resources: [`${artifactS3Bucket.bucketArn}/*`]
-          })
-        ]
-      })
+      statements: [
+        new PolicyStatement({
+          sid: 'CreatePortfolioShare',
+          actions: ['servicecatalog:CreatePortfolioShare'],
+          resources: [`arn:aws:catalog:${this.region}:${this.account}:portfolio/*`]
+        }),
+        // Allows accountHandler to get portfolioId based on portfolioName
+        // '*/*' is the minimum permission required because ListPortfolios API does not allow filtering
+        new PolicyStatement({
+          sid: 'ListPortfolios',
+          actions: ['servicecatalog:ListPortfolios'],
+          resources: [`arn:aws:servicecatalog:${this.region}:${this.account}:*/*`]
+        }),
+        new PolicyStatement({
+          actions: ['kms:Decrypt', 'kms:GenerateDataKey', 'kms:GetKeyPolicy', 'kms:PutKeyPolicy'],
+          resources: [`arn:aws:kms:${this.region}:${this.account}:key/*`],
+          sid: 'KMSAccess'
+        }),
+        new PolicyStatement({
+          sid: 'AssumeRole',
+          actions: ['sts:AssumeRole'],
+          // Confirm the suffix `hosting-account-role` matches with the suffix in `onboard-account.cfn.yaml`
+          resources: ['arn:aws:iam::*:role/*hosting-account-role']
+        }),
+        new PolicyStatement({
+          sid: 'GetLaunchConstraint',
+          actions: [
+            'iam:GetRole',
+            'iam:GetRolePolicy',
+            'iam:ListRolePolicies',
+            'iam:ListAttachedRolePolicies'
+          ],
+          resources: [launchConstraintRole.roleArn]
+        }),
+        new PolicyStatement({
+          sid: 'ShareSSM',
+          actions: ['ssm:ModifyDocumentPermission'],
+          resources: [
+            this.formatArn({ service: 'ssm', resource: 'document', resourceName: `${this.stackName}-*` })
+          ]
+        }),
+        new PolicyStatement({
+          sid: 'Cloudformation',
+          actions: ['cloudformation:DescribeStacks'],
+          resources: [this.stackId]
+        }),
+        new PolicyStatement({
+          sid: 'S3Bucket',
+          actions: ['s3:GetObject'],
+          resources: [`${artifactS3Bucket.bucketArn}/*`]
+        })
+      ]
+    });
 
     if (!_.isEmpty(amiIdsList)) {
       lambdaPolicy.addStatements(

--- a/solutions/swb-ui/src/pages/environments/index.tsx
+++ b/solutions/swb-ui/src/pages/environments/index.tsx
@@ -139,7 +139,7 @@ const Environment: NextPage = () => {
   const connectButtonEnableStatuses: string[] = ['AVAILABLE', 'STARTED', 'COMPLETED'];
   const startButtonEnableStatuses: string[] = ['STOPPED'];
   const stopButtonEnableStatuses: string[] = ['AVAILABLE', 'STARTED', 'COMPLETED'];
-  const terminateButtonEnableStatuses: string[] = ['FAILED', 'STOPPED', 'COMPLETED'];
+  const terminateButtonEnableStatuses: string[] = ['FAILED', 'STOPPED'];
   // Constant buttons should show loading based on statuses in the array
   const stopButtonLoadingStatuses: string[] = ['STOPPING'];
   const terminateButtonLoadingStatuses: string[] = ['TERMINATING'];


### PR DESCRIPTION
…add kms perm for accountHandler

Issue #, if available:

Description of changes:
* EnvType and EnvTypeConfig POST/PUT routes now grab user from res.locals.user
* Terminate button in workspace UI now disabled if workspace is in AVAILABLE state
* Added KMS Decrypt and GenerateDataKey permissions for account handler

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.