### PR TITLE
fix: duplicate CF calls

### DIFF
--- a/workbench-core/environments/src/utilities/hostingAccountLifecycleService.ts
+++ b/workbench-core/environments/src/utilities/hostingAccountLifecycleService.ts
@@ -277,11 +277,8 @@ export default class HostingAccountLifecycleService {
       StackName: hostingAccountStackName
     });
 
-    const describeCfResponse = await hostingAccountAwsService.clients.cloudformation.describeStacks({
-      StackName: hostingAccountStackName
-    });
-    if (['CREATE_COMPLETE', 'UPDATE_COMPLETE'].includes(describeCfResponse.Stacks![0]!.StackStatus!)) {
-      const outputs: Output[] = describeCfResponse.Stacks![0]!.Outputs as Output[];
+    if (['CREATE_COMPLETE', 'UPDATE_COMPLETE'].includes(describeStackResponse.Stacks![0]!.StackStatus!)) {
+      const outputs: Output[] = describeStackResponse.Stacks![0]!.Outputs as Output[];
       const vpcId = outputs.find((output) => {
         return output.OutputKey === 'VPC';
       })!.OutputValue;


### PR DESCRIPTION
Issue #, if available:

Description of changes:
fix: duplicate CF calls.

We called cloudformation twice to get Cloudformation stack details, when we only need to call CF once. 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.