### PR TITLE
fix: runLocally script

### DIFF
--- a/solutions/swb-reference/scripts/runLocally.sh
+++ b/solutions/swb-reference/scripts/runLocally.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-shortName=$(cat src/config/${STAGE}.yaml | grep awsRegionShortName: | awk '{print $NF}')
-region=$(cat src/config/${STAGE}.yaml | grep awsRegion: | awk '{print $NF}')
+shortName=$(cat src/config/${STAGE}.yaml | grep awsRegionShortName: | cut -f1 -d "#" | awk '{print $NF}')
+region=$(cat src/config/${STAGE}.yaml | grep awsRegion: | cut -f1 -d "#" | awk '{print $NF}')
 stackName="swb-${STAGE}-${shortName}"
 
 # SWBStack.ts read this value to set up API to be run locally


### PR DESCRIPTION
Issue #, if available:

Description of changes:

A config file can have comments in it like shown below
```
stage: dev
awsRegion: us-east-2
awsRegionShortName: oh #two or three letter abbreviation for the region. You can choose your own abbreviation
```

In this case `awsRegionShortName` has a comment in it specified by `#`. The bash script only parse the last word in a line, which is not accurate. In this case it should remove all text after `#` before grabbing the last word in the line.


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.