### PR TITLE
fix: authN verify token fix

### DIFF
--- a/common/changes/@aws/workbench-core-authentication/fix-authn-verify-token-fix_2022-08-16-19-54.json
+++ b/common/changes/@aws/workbench-core-authentication/fix-authn-verify-token-fix_2022-08-16-19-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@aws/workbench-core-authentication",
+      "comment": "Fixed bug in authenticationMiddleware where verifyToken used Authorization header instead of access_token cookie",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@aws/workbench-core-authentication"
+}

--- a/workbench-core/authentication/src/authenticationMiddleware.ts
+++ b/workbench-core/authentication/src/authenticationMiddleware.ts
@@ -138,10 +138,12 @@ export function verifyToken(
 ): (req: Request, res: Response, next: NextFunction) => Promise<void> {
   return async function (req: Request, res: Response, next: NextFunction) {
     const { ignoredRoutes, loggingService } = options || {};
+
     if (has(ignoredRoutes, req.path) && get(get(ignoredRoutes, req.path), req.method)) {
       next();
     } else {
-      const accessToken = req.headers ? req.headers.authorization : undefined;
+      const accessToken = req.cookies.access_token;
+
       if (typeof accessToken === 'string') {
         try {
           const decodedAccessToken = await authenticationService.validateToken(accessToken);


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Fixed bug where verifyToken in authenticationMiddleware still used Authorization header for token verification

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.