### PR TITLE
test(swb-reference): adding GetEnvironment and GetEnvironmentConnection integ tests

### DIFF
--- a/solutions/swb-reference/integration-tests/tests/isolated/environments/get.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/environments/get.test.ts
@@ -8,7 +8,7 @@ import Setup from '../../../support/setup';
 import HttpError from '../../../support/utils/HttpError';
 import { checkHttpError } from '../../../support/utils/utilities';
 
-describe('environments connection negative tests', () => {
+describe('get environment negative tests', () => {
   const setup: Setup = new Setup();
   let adminSession: ClientSession;
 
@@ -27,7 +27,7 @@ describe('environments connection negative tests', () => {
   test('environment does not exist', async () => {
     const fakeEnvId = '927ff6bd-9d0e-44d0-b754-47ee50e68edb';
     try {
-      await adminSession.resources.environments.environment(fakeEnvId).connect();
+      await adminSession.resources.environments.environment(fakeEnvId).get();
     } catch (e) {
       checkHttpError(
         e,


### PR DESCRIPTION
Issue #, if available:

Description of changes: Added negative integration tests for:
* GetEnvironment on an environment that does not exist
* GetEnvironmentConnection on an environment that does not exist


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [ ] Have you successfully deployed to an AWS account with your changes?
* [ ] Have you written new tests for your core changes, as applicable?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.