### PR TITLE
fix: pull awsRegion from cfOutput

### DIFF
--- a/solutions/swb-reference/scripts/generateCognitoTokens.js
+++ b/solutions/swb-reference/scripts/generateCognitoTokens.js
@@ -14,13 +14,6 @@ const fs = require('fs');
 const { CognitoTokenService } = require('@aws/workbench-core-base');
 const Csrf = require('csrf');
 
-const config = yaml.load(
-  // __dirname is a variable that reference the current directory. We use it so we can dynamically navigate to the
-  // correct file
-  // eslint-disable-next-line security/detect-non-literal-fs-filename
-  fs.readFileSync(join(__dirname, `../integration-tests/config/${process.env.STAGE}.yaml`), 'utf8') // nosemgrep
-);
-
 let outputs;
 try {
   const apiStackOutputs = JSON.parse(
@@ -36,7 +29,7 @@ try {
 
 const clientId = outputs.cognitoUserPoolClientId;
 const userPoolId = outputs.cognitoUserPoolId;
-const region = config.awsRegion;
+const region = outputs.awsRegion;
 const username = process.argv[2];
 const password = process.argv[3];
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
fix: pull awsRegion from cfnOutput

This fix pulls the `awsRegion` from cfnOutput instead of integration test config. 

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.