### PR TITLE
fix: use CfnDocument

### DIFF
--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -217,7 +217,6 @@ importers:
       aws-lambda: ^1.0.7
       aws-sdk-client-mock: ^0.6.2
       axios: ^0.27.1
-      cdk-ssm-document: ^3.1.1
       constructs: ^10.0.0
       csrf: ^3.1.0
       cypress: ^10.6.0
@@ -283,7 +282,6 @@ importers:
       aws-cdk-lib: 2.29.1_constructs@10.1.25
       aws-lambda: 1.0.7
       axios: 0.27.2
-      cdk-ssm-document: 3.1.1_8d994d7bf27edab84c843ce1928354a1
       constructs: 10.1.25
       cypress: 10.6.0
       depcheck: 1.4.3
@@ -8504,18 +8502,6 @@ packages:
       aws-cdk-lib: 2.29.1_constructs@10.1.25
       constructs: 10.1.25
     dev: true
-
-  /cdk-ssm-document/3.1.1_8d994d7bf27edab84c843ce1928354a1:
-    resolution: {integrity: sha512-mvw3M4hqI2UgGwWihUeCxp93UedOd29aU7Qx1QQfdKmO4DOHx5DsTtK51uoT5wlw920C9eRvzIAIPLK3lQr1VA==}
-    peerDependencies:
-      aws-cdk-lib: ^2.0.0
-      constructs: ^10.0.0
-    dependencies:
-      aws-cdk-lib: 2.29.1_constructs@10.1.25
-      constructs: 10.1.25
-    dev: true
-    bundledDependencies:
-      - js-yaml
 
   /chalk/2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}

--- a/solutions/swb-reference/package.json
+++ b/solutions/swb-reference/package.json
@@ -87,7 +87,6 @@
     "aws-lambda": "^1.0.7",
     "aws-sdk-client-mock": "^0.6.2",
     "axios": "^0.27.1",
-    "cdk-ssm-document": "^3.1.1",
     "constructs": "^10.0.0",
     "cypress": "^10.6.0",
     "depcheck": "^1.4.3",

--- a/solutions/swb-reference/src/environment/workflow.ts
+++ b/solutions/swb-reference/src/environment/workflow.ts
@@ -4,12 +4,11 @@
  */
 
 /* eslint-disable no-new */
-// cdk-ssm-document is used instead of 'aws-cdk-lib/aws-ssm` because aws-ssm creates new SSM documents instead of updating existing SSM document
-// https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/339
 import fs from 'fs';
 import { join } from 'path';
 import { CfnOutput, Stack } from 'aws-cdk-lib';
-import { Document } from 'cdk-ssm-document';
+import { CfnDocument } from 'aws-cdk-lib/aws-ssm';
+import yaml from 'js-yaml';
 import { getConstants } from '../constants';
 
 export default class Workflow {
@@ -27,19 +26,20 @@ export default class Workflow {
     envTypes.forEach((envType) => {
       const docTypes = ['Launch', 'Terminate'];
       docTypes.forEach((docType) => {
-        const cfnDoc = new Document(this._stack, `${this._capitalizeFirstLetter(envType)}${docType}`, {
-          name: `${this._stack.stackName}-${this._capitalizeFirstLetter(envType)}${docType}`,
-          documentType: 'Automation',
-          // __dirname is a variable that reference the current directory. We use it so we can dynamically navigate to the
-          // correct file
+        const ssmDoc = yaml.load(
           // eslint-disable-next-line security/detect-non-literal-fs-filename
-          content: fs // nosemgrep
-            .readFileSync(
-              join(__dirname, `../../../src/environment/${envType}/${envType}${docType}SSM.yaml`),
-              'utf8'
-            )
-            .toString()
+          fs.readFileSync(
+            join(__dirname, `../../../src/environment/${envType}/${envType}${docType}SSM.yaml`),
+            'utf8'
+          )
+        );
+
+        const cfnDoc = new CfnDocument(this._stack, `${this._capitalizeFirstLetter(envType)}${docType}`, {
+          content: ssmDoc,
+          documentType: 'Automation',
+          updateMethod: 'NewVersion'
         });
+
         new CfnOutput(
           this._stack,
           `${this._capitalizeFirstLetter(envType)}${docType}${SSM_DOC_OUTPUT_KEY_SUFFIX}`,
@@ -47,7 +47,7 @@ export default class Workflow {
             value: this._stack.formatArn({
               service: 'ssm',
               resource: 'document',
-              resourceName: cfnDoc.name
+              resourceName: cfnDoc.ref
             })
           }
         );


### PR DESCRIPTION
Issue #, if available:
GALI-1663

Description of changes:
Replaced `cdk-ssm-document` with `CfnDocument` provided by CDK. 

**Testing**
* If SSM document changed, a new version is created in AWS account
* If SSM document is not changed, no changes are made to SSM documents in AWS account

Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x] Have you successfully deployed to an AWS account with your changes?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.