### PR TITLE
fix: allow cdk synth in swb-ui without stage file

### DIFF
--- a/solutions/swb-ui/infrastructure/package.json
+++ b/solutions/swb-ui/infrastructure/package.json
@@ -21,7 +21,6 @@
     "build:test": "rushx build && rushx test",
     "cdk": "cdk",
     "cdk-deploy": "rushx build && cdk deploy --all --require-approval never --outputs-file ./src/config/${STAGE}.json",
-    "cdk-synth": "STAGE=testEnv SYNTH_REGION_SHORTNAME=va SYNTH_REGION=us-east-1 cdk synth",
     "check-license-header": "license-check-and-add check -f license-add-config.json",
     "license-checker": "license-checker --onlyAllow 'MIT; Apache-2.0; ISC; BSD'",
     "sort-package-json": "sort-package-json package.json",

--- a/solutions/swb-ui/infrastructure/package.json
+++ b/solutions/swb-ui/infrastructure/package.json
@@ -21,6 +21,7 @@
     "build:test": "rushx build && rushx test",
     "cdk": "cdk",
     "cdk-deploy": "rushx build && cdk deploy --all --require-approval never --outputs-file ./src/config/${STAGE}.json",
+    "cdk-synth": "STAGE=testEnv SYNTH_REGION_SHORTNAME=va SYNTH_REGION=us-east-1 cdk synth",
     "check-license-header": "license-check-and-add check -f license-add-config.json",
     "license-checker": "license-checker --onlyAllow 'MIT; Apache-2.0; ISC; BSD'",
     "sort-package-json": "sort-package-json package.json",

--- a/solutions/swb-ui/infrastructure/src/constants.ts
+++ b/solutions/swb-ui/infrastructure/src/constants.ts
@@ -68,6 +68,14 @@ function getConstants(): {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getAPIOutputs(): { awsRegionShortName: string; apiUrlOutput: string; awsRegion: string } {
   try {
+    if (process.env.SYNTH_REGION_SHORTNAME && process.env.SYNTH_REGION)
+      //allow environment variable override for synth pipeline check
+      return {
+        awsRegionShortName: process.env.SYNTH_REGION_SHORTNAME,
+        apiUrlOutput: '',
+        awsRegion: process.env.SYNTH_REGION
+      };
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const apiStackOutputs: any = JSON.parse(
       // __dirname is a variable that reference the current directory. We use it so we can dynamically navigate to the
@@ -80,7 +88,9 @@ function getAPIOutputs(): { awsRegionShortName: string; apiUrlOutput: string; aw
     const outputs = apiStackOutputs[apiStackName];
 
     if (!outputs.awsRegionShortName || !outputs.apiUrlOutput || !outputs.awsRegion) {
-      throw new Error(`Configuration file for ${process.env.STAGE} was found with incorrect format. Please deploy application swb-reference and try again.`); //validate when API unsuccessfully finished and UI is deployed
+      throw new Error(
+        `Configuration file for ${process.env.STAGE} was found with incorrect format. Please deploy application swb-reference and try again.`
+      ); //validate when API unsuccessfully finished and UI is deployed
     }
     return {
       awsRegionShortName: outputs.awsRegionShortName,


### PR DESCRIPTION
…ine check

Issue #, if available:
GALI-1863
Description of changes:
Allow cdk synth for swb-ui without stage file ,so we can run pipeline checks on cdk template
Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [x ] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.