### PR TITLE
chore: do not require account id and bucket name from user

### DIFF
--- a/solutions/swb-app/src/datasetRoutes.ts
+++ b/solutions/swb-app/src/datasetRoutes.ts
@@ -19,7 +19,9 @@ import { processValidatorResult } from './validatorHelper';
 export function setUpDSRoutes(
   router: Router,
   dataSetService: DataSetService,
-  dataSetStoragePlugin: DataSetsStoragePlugin
+  dataSetStoragePlugin: DataSetsStoragePlugin,
+  datasetStorageAccount: string,
+  mainAccountId: string
 ): void {
   // creates new prefix in S3 (assumes S3 bucket exist already)
   router.post(
@@ -28,11 +30,12 @@ export function setUpDSRoutes(
       processValidatorResult(validate(req.body, CreateDataSetSchema));
       const dataSet = await dataSetService.provisionDataSet(
         req.body.datasetName,
-        req.body.storageName,
+        datasetStorageAccount,
         req.body.path,
-        req.body.awsAccountId,
+        mainAccountId,
         dataSetStoragePlugin
       );
+
       res.status(201).send(dataSet);
     })
   );
@@ -44,9 +47,9 @@ export function setUpDSRoutes(
       processValidatorResult(validate(req.body, CreateDataSetSchema));
       const dataSet = await dataSetService.importDataSet(
         req.body.datasetName,
-        req.body.storageName,
+        datasetStorageAccount,
         req.body.path,
-        req.body.awsAccountId,
+        mainAccountId,
         dataSetStoragePlugin
       );
       res.status(201).send(dataSet);

--- a/solutions/swb-app/src/generateRouter.ts
+++ b/solutions/swb-app/src/generateRouter.ts
@@ -102,7 +102,13 @@ export function generateRouter(apiRouteConfig: ApiRouteConfig): Express {
   );
 
   setUpEnvRoutes(router, apiRouteConfig.environments, apiRouteConfig.environmentService);
-  setUpDSRoutes(router, apiRouteConfig.dataSetService, apiRouteConfig.dataSetsStoragePlugin);
+  setUpDSRoutes(
+    router,
+    apiRouteConfig.dataSetService,
+    apiRouteConfig.dataSetsStoragePlugin,
+    process.env.S3_DATASET_BUCKET_NAME!,
+    process.env.MAIN_ACCOUNT_ID!
+  );
   setUpAccountRoutes(router, apiRouteConfig.account);
   setUpAuthRoutes(router, authenticationService, logger);
   setUpUserRoutes(router, userManagementService);

--- a/solutions/swb-reference/SETUP_v2p1.md
+++ b/solutions/swb-reference/SETUP_v2p1.md
@@ -279,18 +279,14 @@ Follow the instructions [here](../swb-ui/README.md#deploy-ui-to-aws) to deploy t
 
 **Create new DataSet**
 
-In POSTMAN this is the `Create DataSet` API
-
-During SWB deployment an S3 bucket for DataSets was created in your main account. Grab the name of that bucket from the CFN stack output (key named `DataSetsBucketName`) in the main account and construct the following API call
+In POSTMAN this is the `Create DataSet` API.
 
 POST `{{API_URL}}/datasets`
 
 ```json
 {
     "datasetName": "<Enter a unique DataSet name>",
-    "storageName": "<Enter the main account DataSets bucket name>",
-    "path": "<Folder name to be created for this in the bucket>",
-    "awsAccountId": "<Main account ID>"
+    "path": "<Folder name to be created for this in the bucket>"
 }
 ```
 

--- a/solutions/swb-reference/SWBv2.postman_collection.json
+++ b/solutions/swb-reference/SWBv2.postman_collection.json
@@ -1,9 +1,8 @@
 {
   "info": {
-    "_postman_id": "c7f31b8c-0e10-4a2c-90f6-38fe38bfe8ed",
+    "_postman_id": "a2b89313-33d5-4f5d-842f-c5ec56431c31",
     "name": "SWBv2 Official",
-    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "_exporter_id": "4320586"
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
     {
@@ -27,7 +26,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"datasetName\": \"testDs\",\n    \"storageName\": \"datasetBucketNameInMainAccount\",\n    \"path\": \"folderName\",\n    \"awsAccountId\": \"mainAccountId\"\n}",
+              "raw": "{\n    \"datasetName\": \"testDs\",\n    \"path\": \"folderName\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -60,7 +59,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n    \"datasetName\": \"testDs\",\n    \"storageName\": \"datasetBucketNameInMainAccount\",\n    \"path\": \"existingFolderName\",\n    \"awsAccountId\": \"mainAccountId\"\n}",
+              "raw": "{\n    \"datasetName\": \"testDs\",\n    \"path\": \"existingFolderName\"\n}",
               "options": {
                 "raw": {
                   "language": "json"
@@ -127,15 +126,6 @@
                 "type": "text"
               }
             ],
-            "body": {
-              "mode": "raw",
-              "raw": "",
-              "options": {
-                "raw": {
-                  "language": "json"
-                }
-              }
-            },
             "url": {
               "raw": "{{API_URL}}/datasets/",
               "host": ["{{API_URL}}"],
@@ -776,7 +766,7 @@
           }
         },
         "url": {
-          "raw": "{{API_URL}}/aws-accounts?Authorization={{ACCESS_TOKEN}}",
+          "raw": "{{API_URL}}/aws-accounts",
           "host": ["{{API_URL}}"],
           "path": ["aws-accounts"]
         }

--- a/solutions/swb-reference/integration-tests/tests/isolated/datasets/create.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/isolated/datasets/create.test.ts
@@ -27,9 +27,7 @@ describe('datasets create negative tests', () => {
 
   const validLaunchParameters = {
     datasetName: randomTextGenerator.getFakeText('fakeName'),
-    storageName: randomTextGenerator.getFakeText('fakeBucket'),
-    path: randomTextGenerator.getFakeText('fakePath'),
-    awsAccountId: randomTextGenerator.getFakeText('fakeAccount')
+    path: randomTextGenerator.getFakeText('fakePath')
   };
 
   describe('missing parameters', () => {
@@ -67,40 +65,6 @@ describe('datasets create negative tests', () => {
       }
     });
 
-    test('storageName', async () => {
-      try {
-        const invalidParam: { [id: string]: string } = { ...validLaunchParameters };
-        delete invalidParam.storageName;
-        await adminSession.resources.datasets.create(invalidParam, false);
-      } catch (e) {
-        checkHttpError(
-          e,
-          new HttpError(400, {
-            statusCode: 400,
-            error: 'Bad Request',
-            message: "requires property 'storageName'"
-          })
-        );
-      }
-    });
-
-    test('awsAccountId', async () => {
-      try {
-        const invalidParam: { [id: string]: string } = { ...validLaunchParameters };
-        delete invalidParam.awsAccountId;
-        await adminSession.resources.datasets.create(invalidParam, false);
-      } catch (e) {
-        checkHttpError(
-          e,
-          new HttpError(400, {
-            statusCode: 400,
-            error: 'Bad Request',
-            message: "requires property 'awsAccountId'"
-          })
-        );
-      }
-    });
-
     test('all parameters', async () => {
       try {
         await adminSession.resources.datasets.create({}, false);
@@ -110,8 +74,7 @@ describe('datasets create negative tests', () => {
           new HttpError(400, {
             statusCode: 400,
             error: 'Bad Request',
-            message:
-              "requires property 'datasetName'. requires property 'storageName'. requires property 'path'. requires property 'awsAccountId'"
+            message: "requires property 'datasetName'. requires property 'path'"
           })
         );
       }

--- a/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
+++ b/solutions/swb-reference/integration-tests/tests/multiStep/dataset.test.ts
@@ -28,8 +28,6 @@ describe('multiStep dataset integration test', () => {
 
     // Create dataset
     const dataSetBody = {
-      storageName: settings.get('DataSetsBucketName'),
-      awsAccountId: settings.get('mainAccountId'),
       path: datasetName, // using same name to help potential troubleshooting
       datasetName
     };

--- a/workbench-core/datasets/src/schemas/createDataSet.ts
+++ b/workbench-core/datasets/src/schemas/createDataSet.ts
@@ -11,12 +11,10 @@ const CreateDataSetSchema: Schema = {
   type: 'object',
   properties: {
     datasetName: { type: 'string' },
-    storageName: { type: 'string' },
-    path: { type: 'string' },
-    awsAccountId: { type: 'string' }
+    path: { type: 'string' }
   },
   additionalProperties: false,
-  required: ['datasetName', 'storageName', 'path', 'awsAccountId']
+  required: ['datasetName', 'path']
 };
 
 export default CreateDataSetSchema;


### PR DESCRIPTION
Issue #, if available:

Description of changes: set account id and storage name on backend instead of user sending those parameters.


Checklist:

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

* [X] Have you successfully deployed to an AWS account with your changes?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.